### PR TITLE
Fix discretization and auto featurizer for polars 0.20

### DIFF
--- a/src/feataz/snapshot.py
+++ b/src/feataz/snapshot.py
@@ -444,7 +444,7 @@ class EWMAggregator(Transformer):
             return out
 
         if groupby:
-            out = df.group_by(groupby, maintain_order=True).map_groups(ewm_group)
+            out = df.group_by(*groupby, maintain_order=True).map_groups(ewm_group)
         else:
             out = ewm_group(df)
         if self.drop_original:


### PR DESCRIPTION
## Summary
- adjust the binary encoder to extract bits with arithmetic so polars expressions work under 0.20
- refactor discretizers to share quantile/bin helpers compatible with the updated Expr.cut API
- keep group-by columns available and delay numeric drops in the auto featurizer while fixing EWM aggregator grouping

## Testing
- pytest tests/test_wine_transforms.py

------
https://chatgpt.com/codex/tasks/task_e_68d1614a26148325a04ae8c251282589